### PR TITLE
Improve SEO partially.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # open-ribbon
-This repository is dedicated to the decompilation of the PS1 game Vib-Ribbon (ビブリボン) [PAL].
-The final objective is to obtain the final source code when decompiling the game.
+This repository is dedicated to the decompilation of **[PAL]** edition of the PS1 game Vib-Ribbon (ビブリボン). <br>
+The objective is to produce an free and open-source reverse-engineered version of the game. <br>
+Documentation about this game and project can be [found here.](https://github.com/open-ribbon/documentation)
 
-#
-## Progress
+
+## Decompilation Progress
 
 | Version      | File name  | Progress
 |--------------|------------|----------


### PR DESCRIPTION
i noticed that https://github.com/open-ribbon/open-ribbon/commit/dffd6339d33ae75452c8971540f91fcc82ff46b8 mentioned improving SEO, but the actual words "open source" are never actually stated _clearly_.

 The main change is to include the terms **"free"** and **"open-source"**, which should also work for the query `"FOSS vib-ribbon"`. Currently the google search results for "vib-ribbon open source" and "vib-ribbon FOSS" return nothing directly linking, just walkthroughs and github topics (which people likely wont click on), or the old version of this repository while it still wasn't an organization (which means a broken **404** page will pop up).

Documentation is also linked too, so web-crawlers (and humans) are more likely to also find the documentation page.

A few suggestions are also to:
- Add the topics `decompilation` and `playstation-decompilation` to catch web crawlers more often.
- Make sure any images uploaded in the future should have a descriptive alt-text.
- The "Are you going trick or treating?" line might potentially confuse and throw off bots.

Of course these guidelines don't have to be followed, but it will help get the word out.