### PR TITLE
Fix Makefile and remove my old guide.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ format:
 check:
 		sha1sum --check $(GAME_ID).sha
 expected: check
+		mkdir expected
 		rm -rf expected/build
 		cp -r build expected/build
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-![image](https://github.com/open-ribbon/open-ribbon/assets/52961795/e189d94c-9d19-4ace-ae25-9f2c17e5b30b)
+[![image](https://github.com/open-ribbon/open-ribbon/assets/52961795/e189d94c-9d19-4ace-ae25-9f2c17e5b30b)](https://github.com/open-ribbon)
 
 
 A WIP decompilation of **PAL** build of the PS1 game Vib-Ribbon (ビブリボン). <br>
 The objective is to produce a free and open-source reverse-engineered version of the game. <br>
 
-Documentation about this game and project can be **[found here.](https://github.com/open-ribbon/documentation)** <br>
+**Documentation** about this game and project can be **[found here.](https://github.com/open-ribbon/documentation)** <br>
 Join our **[Discord](https://discord.gg/n5TPTBvGjE)** server to discuss the project.
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![image](https://github.com/open-ribbon/open-ribbon/assets/52961795/e189d94c-9d19-4ace-ae25-9f2c17e5b30b)
 
 
-WIP decompilation of **PAL** build of the PS1 game Vib-Ribbon (ビブリボン). <br>
+A WIP decompilation of **PAL** build of the PS1 game Vib-Ribbon (ビブリボン). <br>
 The objective is to produce a free and open-source reverse-engineered version of the game. <br>
 
 Documentation about this game and project can be **[found here.](https://github.com/open-ribbon/documentation)** <br>
@@ -25,7 +25,7 @@ However, due to current limitations, this decompilation is written in C.
 ## How to build
 
 Place all the necessary PSX executable files in the `iso` directory (e.g. `MAIN_G.EXE`) first.
-`.bin`/`.cue` files will not work; in that case, you will have to extract it manually from the binary yourself via a program such as `binwalk`.
+If you don't currently have the executables needed to decompile the game, please follow [this guide](https://open-ribbon.github.io/documentation/#decompilation/file-ext/#extracting-from-biniso-file) on how to extract the files from your copy of Vib-Ribbon.
 
  1. Run `make extract` to generate the assembly files in the `asm/` directory
  1. Run `make` to compile the binaries in the `build/` directory


### PR DESCRIPTION
The Makefile didn't create the `expected` directory, which causes the build to error for me when it can't find the folder.
I'm also suggesting that my old tutorial to dump the `.EXE` files either be removed or be rewritten, because it's too ambiguous to actually be useful for beginners to understand.